### PR TITLE
hotfix: use $upstream_forward instead of goto for unmatched ip response

### DIFF
--- a/mosdns/config-v5.yml
+++ b/mosdns/config-v5.yml
@@ -166,7 +166,7 @@ plugins:
       - exec: metrics_collector remote_forward
       - exec: $remote_forward
       - matches: "resp_ip $direct_ip"
-        exec: goto domestic_sequence
+        exec: $domestic_forward
       - exec: goto ttl_sequence
 
   ## --- Fallback IP Sequence --- ##
@@ -174,7 +174,7 @@ plugins:
   - tag: "direct_ip_sequence"
     type: sequence
     args:
-      - exec: goto remote_sequence
+      - exec: $remote_forward
       - matches: "resp_ip $direct_ip"
         exec: drop_resp
   


### PR DESCRIPTION
## Summary

Following documentation: https://irine-sistiana.gitbook.io/mosdns-wiki/mosdns-v5/ru-he-pei-zhi-mosdns/sequence-cha-jian#goto

`goto` will terminate any consequential actions, which is undesired in `direct_ip_sequence` and in `remote_sequence`