### PR TITLE
refactor/optimize: rework ip-sequence logic, disable always_standby

### DIFF
--- a/mosdns/config-v5.yml
+++ b/mosdns/config-v5.yml
@@ -170,22 +170,25 @@ plugins:
       - exec: goto ttl_sequence
 
   ## --- Fallback IP Sequence --- ##
-  # if response has direct IP, drop it
-  - tag: "direct_ip_sequence"
+  # if response has direct IP, forward to domestic upstream
+  - tag: "ip_sequence"
     type: sequence
     args:
+      - exec: query_summary ip_forward
+      - exec: metrics_collector ip_forward
       - exec: $remote_forward
       - matches: "resp_ip $direct_ip"
-        exec: drop_resp
+        exec: $domestic_forward
+      - exec: goto ttl_sequence
   
   ## --- Fallback --- ##
   - tag: "fallback"
     type: fallback
     args:
-      primary: direct_ip_sequence
+      primary: ip_sequence
       secondary: remote_sequence
       threshold: 500  # no response timeout, default value is 500ms
-      always_standby: true
+      always_standby: false # do not use concurrency; if primary fails, exec secondary
 
   ## --- Main Sequence --- ##
   - tag: "main_sequence"


### PR DESCRIPTION
## Summary

Rework `ip-sequence` logic. Ideally, we should not use concurrency for fallback as it will forward the request twice to the same upstream server. However, we cannot forward the request to `domestic_sequence` as it is very likely to be polluted.

## Changelogs

- Set `always_standby` to `false` to disable concurrency in fallback.
- Add `metrics_collector` for `ip_sequence`

## Test Results

<img width="1153" alt="CleanShot 2023-09-17 at 00 57 11@2x" src="https://github.com/techprober/mosdns-lxc-deploy/assets/31861128/36e78210-e975-44a8-879d-12670a1cd558">
