### PR TITLE
patch: do not block qtype-12

### DIFF
--- a/mosdns/config-v5.yml
+++ b/mosdns/config-v5.yml
@@ -204,8 +204,6 @@ plugins:
       - matches: has_resp
         exec: accept # end if reponse found in cache
 
-      - matches: qtype 12
-        exec: reject 3
       - matches: qtype 65
         exec: reject 3
 


### PR DESCRIPTION
## Summary

Do not block Qtype 12 (PTR) - use for reverse lookup purpose.

According to wikipedia:

> Pointer to a [canonical name](https://en.wikipedia.org/wiki/Canonical_name). Unlike a CNAME, DNS processing stops and just the name is returned. The most common use is for implementing [reverse DNS lookups](https://en.wikipedia.org/wiki/Reverse_DNS_lookup), but other uses include such things as [DNS-SD](https://en.wikipedia.org/wiki/DNS-SD).

https://en.wikipedia.org/wiki/List_of_DNS_record_types